### PR TITLE
Fix download strategy for brew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,6 @@ brews:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     url_template: "http://github.com/kekeniker/spa/releases/{{ .Tag }}/{{ .ArtifactName }}"
-    download_strategy: CurlDownloadStrategy.
     commit_author:
       name: goreleaserbot
       email: goreleaser@carlosbecker.com


### PR DESCRIPTION
## What
Remove the `download_strategy`.

## Why
No need to specify and existing strategy contains typo.