### PR TITLE
Add get secret and create kubeconfig

### DIFF
--- a/cmd/service_account/get.go
+++ b/cmd/service_account/get.go
@@ -1,0 +1,91 @@
+package service_account
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/kekeniker/spa/pkg/client"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type getOption struct {
+	dryRun     bool
+	namespace  string
+	saOption   *saOption
+	saName     string
+	outputPath string
+	username   string
+}
+
+func newServiceAccountGetCommand(sa *saOption) *cobra.Command {
+	opts := &getOption{
+		saOption: sa,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "create",
+		Aliases: []string{"c"},
+		RunE:    serviceAccountGetRun(opts),
+	}
+
+	cmd.PersistentFlags().BoolVarP(&opts.dryRun, "dryRun", "", defaultDryRun, "Dry run the operation")
+	cmd.PersistentFlags().StringVarP(&opts.namespace, "namespace", "n", defaultNamespace, "Namespace to create the resources")
+	cmd.PersistentFlags().StringVarP(&opts.saName, "service-account-name", "", defaultServiceAccountName, "Custom service account name")
+	cmd.PersistentFlags().StringVarP(&opts.outputPath, "output", "o", "", "Path of the kube config output")
+	cmd.PersistentFlags().StringVarP(&opts.username, "username", "u", defaultUsername, "AuthInfo username of the kubernetes context")
+	return cmd
+}
+
+func serviceAccountGetRun(opt *getOption) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+		opts := []client.ClientOption{}
+		if opt.dryRun {
+			opts = append(opts, client.WithDryRun())
+		}
+
+		client, err := client.NewClient(ctx, opts...)
+		if err != nil {
+			return err
+		}
+
+		sa, err := client.GetServiceAccount(ctx, opt.saName, opt.namespace)
+		if err != nil {
+			return err
+		}
+
+		secret, err := client.GetSecret(ctx, sa.Secrets[0].Name, opt.namespace)
+		if err != nil {
+			return err
+		}
+
+		if opt.outputPath != "" {
+			cfg, err := client.CreateKubeConfig(secret, opt.username)
+			if err != nil {
+				return err
+			}
+
+			if opt.outputPath == "-" {
+				b, err := clientcmd.Write(*cfg)
+				if err != nil {
+					return err
+				}
+
+				fmt.Fprintf(os.Stdout, string(b))
+				return nil
+			}
+
+			if err := clientcmd.WriteToFile(*cfg, opt.outputPath); err != nil {
+				return err
+			}
+
+			return nil
+		}
+
+		// Print secret if no output path is specified
+		fmt.Print(secret.Data["token"])
+		return nil
+	}
+}

--- a/cmd/service_account/service_account.go
+++ b/cmd/service_account/service_account.go
@@ -19,6 +19,7 @@ func NewServiceAccountCommand(rootOpt *option.RootOption) *cobra.Command {
 		Aliases: []string{"sa"},
 	}
 
+	cmd.AddCommand(newServiceAccountGetCommand(opt))
 	cmd.AddCommand(newServiceAccountCreateCommand(opt))
 	return cmd
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,13 +17,17 @@ var _ Client = (*client)(nil)
 
 // Client interface represents the API for the Kubernetes API cluster supported for spin-admin
 type Client interface {
+	// Create
 	CreateServiceAccount(ctx context.Context, name, namespace string) (*corev1.ServiceAccount, *corev1.Secret, error)
 	CreateRole(ctx context.Context, roleName, namespace string) (*rbacv1.Role, error)
 	CreateRoleBinding(ctx context.Context, serviceAccountName, roleName, roleBindingName, namespace string) (*rbacv1.RoleBinding, error)
 	CreateClusterRole(ctx context.Context, roleName string) (*rbacv1.ClusterRole, error)
 	CreateClusterRoleBinding(ctx context.Context, serviceAccountName, roleName, rbName, namespace string) (*rbacv1.ClusterRoleBinding, error)
-
 	CreateKubeConfig(secret *corev1.Secret, username string) (*api.Config, error)
+
+	// Get
+	GetServiceAccount(ctx context.Context, name, namespace string) (*corev1.ServiceAccount, error)
+	GetSecret(ctx context.Context, name, namespace string) (*corev1.Secret, error)
 }
 
 // ClientOption is for additional client configurations.

--- a/pkg/client/secret.go
+++ b/pkg/client/secret.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetSecret ...
+func (c *client) GetSecret(ctx context.Context, name, namespace string) (*corev1.Secret, error) {
+	return c.clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+}

--- a/pkg/client/service_account.go
+++ b/pkg/client/service_account.go
@@ -8,6 +8,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func (c *client) GetServiceAccount(ctx context.Context, name, namespace string) (*v1.ServiceAccount, error) {
+	return c.clientset.CoreV1().ServiceAccounts(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
 func (c *client) CreateServiceAccount(ctx context.Context, name, namespace string) (*v1.ServiceAccount, *v1.Secret, error) {
 	_, err := c.clientset.CoreV1().ServiceAccounts(namespace).Create(ctx, &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{Name: name},


### PR DESCRIPTION
## What
Add `spa sa get` command.

## Why
To create Kubeconfig from existing service account.
