### PR TITLE
Fix get command name

### DIFF
--- a/cmd/service_account/get.go
+++ b/cmd/service_account/get.go
@@ -25,8 +25,8 @@ func newServiceAccountGetCommand(sa *saOption) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:     "create",
-		Aliases: []string{"c"},
+		Use:     "get",
+		Aliases: []string{"g"},
 		RunE:    serviceAccountGetRun(opts),
 	}
 


### PR DESCRIPTION
## What
Fix `get` command of `service-account` command.


## Why
Bug.